### PR TITLE
Fix save_notebook's python script save

### DIFF
--- a/lib/simple_notebook_manager.py
+++ b/lib/simple_notebook_manager.py
@@ -317,7 +317,7 @@ class SimpleNotebookManager(NotebookManager):
 
         # Save .py script as well
         py_stream = StringIO()
-        current.write(nb, py_stream, u'json')
+        current.write(nb, py_stream, u'py')
         notebook['py'] = py_stream.getvalue()
         notebook['py_last_modified'] = tz.utcnow()
         py_stream.close()


### PR DESCRIPTION
Looks like a simple copy/paste mistake - where it was supposed to save the notebook as a python script in memory, it was saving to the same format (json) twice.
